### PR TITLE
Add A Warning for Comma Dangles

### DIFF
--- a/eslintrc.js
+++ b/eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
         asyncArrow: 'always',
         named: 'never'
       }
-    ]
+    ],
+    'comma-dangle': ['warn', 'always-multiline'],
   }
 }


### PR DESCRIPTION
I would like to propose that we start embracing [column dangles](https://eslint.org/docs/rules/comma-dangle) (also known as trailing commas) in our code.

This allows for much cleaner git diffs and can save us potential errors down the road (alphabetizing lines for example). Check out the diff for this PR to see what I mean...added one line, but it shows as 2 additions and 1 deletion (misleading).

Our transpiler (babel) will strip them out for transpiled code, so we don't need to work about issues with legacy browsers.

We've been trained (or some of us have) to see a trailing comma as bad. However, this is becoming a popular formatting choice by a number of leaders in our space:
- [Mozilla](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas)
- [AirBnB](https://github.com/airbnb/javascript#commas--dangling)
- etc...