### PR TITLE
:green_heart: stop warnings for ESLint versions >=5

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Blake Knight <bknight@gsandf.com> (http://blakek.me/)",
   "license": "MIT",
   "peerDependencies": {
-    "eslint": "3 || 4"
+    "eslint": ">=3"
   },
   "dependencies": {
     "eslint-config-standard": "^12.0.0",


### PR DESCRIPTION
Previously, installing any recent ESLint version would show warnings when installing, even though the package works fine.

This should help quieten those warnings by saying any version of ESLint greater than 3 is fine.

The reason eslint@3 is the cutoff is that's when ESLint changed from numbers for error levels to words. For example, `2` was changed to `"error"`.

Resolves #6